### PR TITLE
Allow comments inside enum lists

### DIFF
--- a/syntaxes/vhdl.tmLanguage.yml
+++ b/syntaxes/vhdl.tmLanguage.yml
@@ -645,6 +645,7 @@ repository:
           - match: ([a-z][a-z0-9_]*)
             captures:
               1: { name: entity.name.type.vhdl }
+          - include: "#comments"
 
   file_declaration:
     # file : label ... ;


### PR DESCRIPTION
Currently, the "ENUM1, --!< COMMENT1" portion of the following snippet is parsed as a single token.

```vhdl
type mytype is (ENUM1, --!< COMMENT1
                ENUM2); --!< COMMENT2
```