### PR TITLE
Additional prefixes for process statement snippets

### DIFF
--- a/snippets/vhdl.yml
+++ b/snippets/vhdl.yml
@@ -180,7 +180,7 @@ subtype:
 # --------------------------------------------------
 
 testbench_process:
-  prefix: tproc
+  prefix: tproc, processt
   description: Testbench Process (No Sensitivity List) 
   scope: source.vhdl
   body:
@@ -190,7 +190,7 @@ testbench_process:
     - "end process $1;"
 
 combinational_process :
-  prefix: cproc
+  prefix: cproc, processc
   description: Combinational Process 
   scope: source.vhdl
   body:
@@ -200,7 +200,7 @@ combinational_process :
     - "end process $1;"
 
 asynchronous_reset_clocked_process :
-  prefix: aproc
+  prefix: aproc, processa
   description: Clocked Process (Asynchronous Reset)  
   scope: source.vhdl
   body:
@@ -214,7 +214,7 @@ asynchronous_reset_clocked_process :
     - "end process $1;"
 
 synchronous_reset_clocked_process :
-  prefix: sproc
+  prefix: sproc, processs
   description: Clocked Process (Synchronous Reset)  
   scope: source.vhdl
   body:

--- a/snippets/vhdl.yml
+++ b/snippets/vhdl.yml
@@ -186,7 +186,7 @@ testbench_process:
   body:
     - "${1:proc_name}: process"
     - "begin"
-    - "$0"
+    - "\t$0"
     - "end process $1;"
 
 combinational_process :
@@ -196,7 +196,7 @@ combinational_process :
   body:
     - "${1:proc_name}: process(${2:sensitivity_list})"
     - "begin"
-    - "$0"
+    - "\t$0"
     - "end process $1;"
 
 asynchronous_reset_clocked_process :
@@ -206,11 +206,11 @@ asynchronous_reset_clocked_process :
   body:
     - "${1:proc_name}: process(${3:clk}, ${4:rst})"
     - "begin"
-    - "if ${4:rst} = ${5:rst_val} then"
-    - "\t$0"
-    - "elsif ${2|rising_edge,falling_edge|}(${3:clk}) then"
-    - "\t"
-    - "end if;"
+    - "\tif ${4:rst} = ${5:rst_val} then"
+    - "\t\t$0"
+    - "\telsif ${2|rising_edge,falling_edge|}(${3:clk}) then"
+    - "\t\t"
+    - "\tend if;"
     - "end process $1;"
 
 synchronous_reset_clocked_process :
@@ -220,13 +220,13 @@ synchronous_reset_clocked_process :
   body:
     - "${1:proc_name}: process(${3:clk})"
     - "begin"
-    - "if ${2|rising_edge,falling_edge|}(${3:clk}) then"
-    - "\tif ${4:rst} = ${5:rst_val} then"
-    - "\t\t$0"
-    - "\telse"
-    - "\t\t"
+    - "\tif ${2|rising_edge,falling_edge|}(${3:clk}) then"
+    - "\t\tif ${4:rst} = ${5:rst_val} then"
+    - "\t\t\t$0"
+    - "\t\telse"
+    - "\t\t\t"
+    - "\t\tend if;"
     - "\tend if;"
-    - "end if;"
     - "end process $1;"
 
 # --------------------------------------------------


### PR DESCRIPTION
I've only learned of the process statement snippets by reading the source code because I'd expected the prefix for such a snippet to start with "process". I've thus added additional prefixes for those snippets. You can now type "process" to get a selection of process snippets.