### PR TITLE
Fixing case sensitivity in enum declaration.

### DIFF
--- a/syntaxes/vhdl.tmLanguage.yml
+++ b/syntaxes/vhdl.tmLanguage.yml
@@ -642,7 +642,7 @@ repository:
         endCaptures:
           1: { name: keyword.operator.vhdl }
         patterns:
-          - match: ([a-z][a-z0-9_]*)
+          - match: (?i)([a-z][a-z0-9_]*)
             captures:
               1: { name: entity.name.type.vhdl }
           - include: "#comments"


### PR DESCRIPTION
Any capital letters inside an enum declaration were not considered part of the type name.