### PR TITLE
Update vhdl.tmLanguage.yml

### DIFF
--- a/syntaxes/vhdl.tmLanguage.yml
+++ b/syntaxes/vhdl.tmLanguage.yml
@@ -635,7 +635,7 @@ repository:
     # (?<=is_) ( ... ) ;
     patterns:
       - name: meta.block.enum_statement.vhdl
-        begin: (?i)(?<=is)\s*(\()
+        begin: (?i)(?<=\bis)\s*(\()
         beginCaptures:
           1: { name: keyword.operator.vhdl }
         end: (?i)(\)\s*;)


### PR DESCRIPTION
Make sure the "is" for an enum_statement is preceded by a word-break, otherwise any signal ending with "is" post-fix will cause the highlighting to be corrupted

ie
```
my_sig_dis <= 42;
         ^--the "is" gets interpreted as the begin pattern of an enum statement.
```