### PR TITLE
Fix highlighting when words begin with end.

### DIFF
--- a/syntaxes/vhdl.tmLanguage.yml
+++ b/syntaxes/vhdl.tmLanguage.yml
@@ -91,7 +91,7 @@ repository:
           2: { name: entity.name.type.vhdl }
           3: { name: keyword.reserved.vhdl }
         end: (?xi)
-          \b(end)\s*
+          \b(end)\b\s*
           (context)?\s*
           ([a-z][a-z0-9_]*)?\s*
           (;)
@@ -122,7 +122,7 @@ repository:
           2: { name: entity.name.type.vhdl }
           3: { name: keyword.reserved.vhdl }
         end: (?xi)
-          \b(end)\s*
+          \b(end)\b\s*
           (entity)?\s*
           ([a-z][a-z0-9_]*)?\s*
           (;)
@@ -154,7 +154,7 @@ repository:
           4: { name: entity.other.inherited-class.vhdl }
           5: { name: keyword.reserved.vhdl }
         end: (?xi)
-          \b(end)\s*
+          \b(end)\b\s*
           (configuration)?\s*
           ([a-z][a-z0-9_]*)?\s*
           (;)
@@ -183,7 +183,7 @@ repository:
           2: { name: entity.name.type.vhdl }
           3: { name: keyword.reserved.vhdl }
         end: (?xi)
-          \b(end)\s*
+          \b(end)\b\s*
           (package(?i:\s+body)?)?\s*
           ([a-z][a-z0-9_]*)?\s*
           (;)
@@ -240,7 +240,7 @@ repository:
           4: { name: entity.other.inherited-class.vhdl }
           5: { name: keyword.reserved.vhdl }
         end: (?xi)
-          \b(end)\s*
+          \b(end)\b\s*
           (architecture)?\s*
           ([a-z][a-z0-9_]*)?\s*
           (;)
@@ -429,7 +429,7 @@ repository:
         beginCaptures:
           1: { name: keyword.reserved.vhdl }
         end: (?xi)
-          \b(end)\s+
+          \b(end)\b\s+
           ((?i:postponed\s+)?process)\s*
           ([a-z][a-z0-9_]*)?
           (;)
@@ -494,7 +494,7 @@ repository:
         beginCaptures:
           1: { name: keyword.reserved.vhdl }
         end: (?xi)
-          \b(end)\s*
+          \b(end)\b\s*
           (pure|impure)?\s*
           (function|procedure)?\s*
           ([a-z][a-z0-9_]*)?\s*


### PR DESCRIPTION
Words like endAddr would be interpreted as the end keyword and would
break highlighting. Added word-boundary to the end checks.